### PR TITLE
Equipment url scraper

### DIFF
--- a/src/AzurLaneWikiScrapers/AzurLaneWikiScraper.cs
+++ b/src/AzurLaneWikiScrapers/AzurLaneWikiScraper.cs
@@ -29,5 +29,11 @@ namespace AzurLaneWikiScrapers
 		/// Scraper used for retrieving event images
 		/// </summary>
 		public Scrapers.EventImagesScraper EventImagesScraper = new Scrapers.EventImagesScraper();
+
+		/// <summary>
+		/// Scraper used for retrieving equipment
+		/// </summary>
+		/// <returns></returns>
+		public Scrapers.EquipmentUrlScraper EquipmentUrlScraper = new Scrapers.EquipmentUrlScraper();
 	}
 }

--- a/src/AzurLaneWikiScrapers/AzurLaneWikiScrapers.csproj
+++ b/src/AzurLaneWikiScrapers/AzurLaneWikiScrapers.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFramework>net5.0</TargetFramework>
 
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Title>Azur Lane Wiki Scrapers</Title>

--- a/src/AzurLaneWikiScrapers/Enums/AzurLaneEquipmentSourceType.cs
+++ b/src/AzurLaneWikiScrapers/Enums/AzurLaneEquipmentSourceType.cs
@@ -1,0 +1,21 @@
+namespace AzurLaneWikiScrapers.Enums
+{
+	public enum AzurLaneEquipmentSourceType
+	{
+		DestroyerGun = 1,
+		LightCruiserGun = 2,
+		HeavyCruiserGun = 4,
+		LargeCruiserGun = 8,
+		BattleshipGun = 16,
+		ShipTorpedo = 32,
+		SubmarineTorpedo = 64,
+		FighterPlane = 128,
+		DiveBomberPlane = 256,
+		TorpedoBomberPlane = 512,
+		Seaplane = 1024,
+		AntiAirGun = 2048,
+		Auxiliary = 4096,
+		Cargo = 8192,
+		AntiSubmarine = 16384,
+	}
+}

--- a/src/AzurLaneWikiScrapers/Models/AzurLaneEquipmentSource.cs
+++ b/src/AzurLaneWikiScrapers/Models/AzurLaneEquipmentSource.cs
@@ -1,0 +1,13 @@
+using AzurLaneWikiScrapers.Enums;
+
+namespace AzurLaneWikiScrapers.Models
+{
+	public class AzurLaneEquipmentSource
+	{
+		public AzurLaneEquipmentSource() { }
+		public string EquipmentId { get; set; }
+		public string Name { get; set; }
+		public string Url { get; set; }
+		public AzurLaneEquipmentSourceType Type { get; set; }
+	}
+}

--- a/src/AzurLaneWikiScrapers/Models/AzurLaneEquipmentSource.cs
+++ b/src/AzurLaneWikiScrapers/Models/AzurLaneEquipmentSource.cs
@@ -5,7 +5,6 @@ namespace AzurLaneWikiScrapers.Models
 	public class AzurLaneEquipmentSource
 	{
 		public AzurLaneEquipmentSource() { }
-		public string EquipmentId { get; set; }
 		public string Name { get; set; }
 		public string Url { get; set; }
 		public AzurLaneEquipmentSourceType Type { get; set; }

--- a/src/AzurLaneWikiScrapers/Models/AzurLaneShipSource.cs
+++ b/src/AzurLaneWikiScrapers/Models/AzurLaneShipSource.cs
@@ -3,11 +3,6 @@ namespace AzurLaneWikiScrapers.Models
 	public class AzurLaneShipSource
 	{
 		public AzurLaneShipSource() { }
-		public AzurLaneShipSource(string shipId, string url)
-		{
-			this.ShipId = shipId;
-			this.Url = url;
-		}
 		public string ShipId { get; set; }
 		public string Name { get; set; }
 		public string Url { get; set; }

--- a/src/AzurLaneWikiScrapers/Scrapers/EquipmentUrlScraper.cs
+++ b/src/AzurLaneWikiScrapers/Scrapers/EquipmentUrlScraper.cs
@@ -16,25 +16,68 @@ namespace AzurLaneWikiScrapers.Scrapers
 			HtmlDocument htmlDoc = new HtmlDocument();
 			HtmlNode tableNode;
 
+			List<(string, string)> xPaths = new List<(string, string)>
+			{
+				("/html/body/div[3]/div[3]/div[5]/div[1]/div/div[4]/table/tbody", "https://azurlane.koumakan.jp/wiki/List_of_Destroyer_Guns"),
+				("/html/body/div[3]/div[3]/div[5]/div[1]/div/div[1]/table/tbody", "https://azurlane.koumakan.jp/wiki/List_of_Light_Cruiser_Guns"),
+				("/html/body/div[3]/div[3]/div[5]/div[1]/div/div[1]/table/tbody", "https://azurlane.koumakan.jp/wiki/List_of_Heavy_Cruiser_Guns"),
+				("/html/body/div[3]/div[3]/div[5]/div[1]/div[2]/div[1]/table/tbody", "https://azurlane.koumakan.jp/wiki/List_of_Large_Cruiser_Guns"),
+				("/html/body/div[3]/div[3]/div[5]/div[1]/div/div[1]/table/tbody", "https://azurlane.koumakan.jp/wiki/List_of_Battleship_Guns"),
+				("/html/body/div[3]/div[3]/div[5]/div[1]/div/div[1]/table/tbody","https://azurlane.koumakan.jp/wiki/List_of_Torpedoes"),
+				("/html/body/div[3]/div[3]/div[5]/div[1]/div/div[1]/table/tbody","https://azurlane.koumakan.jp/wiki/List_of_Submarine_Torpedoes"),
+				("/html/body/div[3]/div[3]/div[5]/div[1]/div/div[1]/table/tbody","https://azurlane.koumakan.jp/wiki/List_of_Fighters"),
+				("/html/body/div[3]/div[3]/div[5]/div[1]/div/div[1]/table/tbody","https://azurlane.koumakan.jp/wiki/List_of_Dive_Bombers"),
+				("/html/body/div[3]/div[3]/div[5]/div[1]/div/div[1]/table/tbody", "https://azurlane.koumakan.jp/wiki/List_of_Torpedo_Bombers"),
+				("/html/body/div[3]/div[3]/div[5]/div[1]/div/div[1]/table/tbody","https://azurlane.koumakan.jp/wiki/List_of_Seaplanes"),
+				("/html/body/div[3]/div[3]/div[5]/div[1]/div/div[1]/table/tbody", "https://azurlane.koumakan.jp/wiki/List_of_AA_Guns"),
+				("/html/body/div[3]/div[3]/div[5]/div[1]/div/div[1]/table/tbody","https://azurlane.koumakan.jp/wiki/List_of_Auxiliary_Equipment"),
+				("/html/body/div[3]/div[3]/div[5]/div[1]/div/div[1]/table/tbody","https://azurlane.koumakan.jp/wiki/List_of_Cargo"),
+				("/html/body/div[3]/div[3]/div[5]/div[1]/div/div[1]/table/tbody", "https://azurlane.koumakan.jp/wiki/List_of_ASW_Equipment")
+			};
+
 			/// <summary>
 			/// Destroyer ships
 			/// </summary>
-			htmlDoc.LoadHtml(new WebClient().DownloadString("https://azurlane.koumakan.jp/List_of_Destroyer_Guns#Max_Rarity"));
-			tableNode = htmlDoc.DocumentNode.SelectSingleNode("/html/body/div[3]/div[3]/div[5]/div[1]/div/div[4]/table/tbody");
 
-			foreach (HtmlNode row in tableNode.Descendants("tr").Skip(1))
+
+			for (int index = 0; index < xPaths.Count; index++)
 			{
-				AzurLaneEquipmentSource source = new AzurLaneEquipmentSource();
-				if (row.Descendants("td").Count() == 0) { continue; }
+				htmlDoc.LoadHtml(new WebClient().DownloadString(xPaths[index].Item2));
+				tableNode = htmlDoc.DocumentNode.SelectSingleNode(xPaths[index].Item1);
+				foreach (HtmlNode row in tableNode.Descendants("tr").Skip(1))
+				{
+					AzurLaneEquipmentSource source = new AzurLaneEquipmentSource();
+					if (row.Descendants("td").Count() == 0) { continue; }
 
-				source.Name = row.Descendants("td").First().InnerText.Replace("\n", "").Trim();
-				source.Url = "https://azurlane.koumakan.jp" + row.Descendants("td").First().Descendants("a").First().Attributes["href"].Value;
-				source.Type = Enums.AzurLaneEquipmentSourceType.DestroyerGun;
+					source.Name = row.Descendants("td").First().InnerText.Replace("\n", "").Trim();
+					source.Url = "https://azurlane.koumakan.jp" + row.Descendants("td").First().Descendants("a").First().Attributes["href"].Value;
 
-				if (sources.Any(s => s.Name == source.Name)) { continue; }
+					switch (index)
+					{
+						case 1: source.Type = Enums.AzurLaneEquipmentSourceType.DestroyerGun; break;
+						case 2: source.Type = Enums.AzurLaneEquipmentSourceType.LightCruiserGun; break;
+						case 3: source.Type = Enums.AzurLaneEquipmentSourceType.HeavyCruiserGun; break;
+						case 4: source.Type = Enums.AzurLaneEquipmentSourceType.LargeCruiserGun; break;
+						case 5: source.Type = Enums.AzurLaneEquipmentSourceType.BattleshipGun; break;
+						case 6: source.Type = Enums.AzurLaneEquipmentSourceType.ShipTorpedo; break;
+						case 7: source.Type = Enums.AzurLaneEquipmentSourceType.SubmarineTorpedo; break;
+						case 8: source.Type = Enums.AzurLaneEquipmentSourceType.FighterPlane; break;
+						case 9: source.Type = Enums.AzurLaneEquipmentSourceType.DiveBomberPlane; break;
+						case 10: source.Type = Enums.AzurLaneEquipmentSourceType.TorpedoBomberPlane; break;
+						case 11: source.Type = Enums.AzurLaneEquipmentSourceType.Seaplane; break;
+						case 12: source.Type = Enums.AzurLaneEquipmentSourceType.AntiAirGun; break;
+						case 13: source.Type = Enums.AzurLaneEquipmentSourceType.Auxiliary; break;
+						case 14: source.Type = Enums.AzurLaneEquipmentSourceType.Cargo; break;
+						case 15: source.Type = Enums.AzurLaneEquipmentSourceType.AntiSubmarine; break;
+					}
 
-				sources.Add(source);
+					if (sources.Any(s => s.Name == source.Name)) { continue; }
+
+					sources.Add(source);
+				}
 			}
+
+
 
 			return sources.ToArray();
 		}

--- a/src/AzurLaneWikiScrapers/Scrapers/EquipmentUrlScraper.cs
+++ b/src/AzurLaneWikiScrapers/Scrapers/EquipmentUrlScraper.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using AzurLaneWikiScrapers.Models;
+using HtmlAgilityPack;
+
+namespace AzurLaneWikiScrapers.Scrapers
+{
+	public class EquipmentUrlScraper
+	{
+		public AzurLaneEquipmentSource[] Execute()
+		{
+			List<AzurLaneEquipmentSource> sources = new List<AzurLaneEquipmentSource>();
+
+			// We will be reusing this variable for all the categories
+			HtmlDocument htmlDoc = new HtmlDocument();
+			HtmlNode tableNode;
+
+			/// <summary>
+			/// Destroyer ships
+			/// </summary>
+			htmlDoc.LoadHtml(new WebClient().DownloadString("https://azurlane.koumakan.jp/List_of_Destroyer_Guns#Max_Rarity"));
+			tableNode = htmlDoc.DocumentNode.SelectSingleNode("/html/body/div[3]/div[3]/div[5]/div[1]/div/div[4]/table/tbody");
+
+			foreach (HtmlNode row in tableNode.Descendants("tr").Skip(1))
+			{
+				AzurLaneEquipmentSource source = new AzurLaneEquipmentSource();
+				if (row.Descendants("td").Count() == 0) { continue; }
+
+				source.Name = row.Descendants("td").First().InnerText.Replace("\n", "").Trim();
+				source.Url = "https://azurlane.koumakan.jp" + row.Descendants("td").First().Descendants("a").First().Attributes["href"].Value;
+				source.Type = Enums.AzurLaneEquipmentSourceType.DestroyerGun;
+
+				if (sources.Any(s => s.Name == source.Name)) { continue; }
+
+				sources.Add(source);
+			}
+
+			return sources.ToArray();
+		}
+	}
+}

--- a/src/AzurLaneWikiScrapersConsole/AzurLaneWikiScrapersConsole.csproj
+++ b/src/AzurLaneWikiScrapersConsole/AzurLaneWikiScrapersConsole.csproj
@@ -11,7 +11,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/src/AzurLaneWikiScrapersConsole/Program.cs
+++ b/src/AzurLaneWikiScrapersConsole/Program.cs
@@ -196,6 +196,9 @@ namespace AzurLaneWikiScrapersConsole
 				AnsiConsole.MarkupLine("[lime]Exported Event Images![/]");
 			}
 
+			/// <summary>
+			/// Export equipment urls
+			/// </summary>
 			if (_downloadEquipmentUrls)
 			{
 				AnsiConsole.Status().Start("Scraping Equipment Urls...", ctx =>

--- a/src/AzurLaneWikiScrapersConsole/Program.cs
+++ b/src/AzurLaneWikiScrapersConsole/Program.cs
@@ -18,10 +18,8 @@ namespace AzurLaneWikiScrapersConsole
 		private static bool _downloadShipData = false;
 		private static bool _downloadShipImages = false;
 		private static bool _downloadShipUrls = false;
-
 		private static bool _downloadEventsData = false;
 		private static bool _downloadEventsImages = false;
-
 		private static bool _downloadEquipmentUrls = false;
 
 		public static List<AzurLaneShip> ships = new List<AzurLaneShip>();

--- a/src/AzurLaneWikiScrapersConsole/Program.cs
+++ b/src/AzurLaneWikiScrapersConsole/Program.cs
@@ -22,6 +22,8 @@ namespace AzurLaneWikiScrapersConsole
 		private static bool _downloadEventsData = false;
 		private static bool _downloadEventsImages = false;
 
+		private static bool _downloadEquipmentUrls = false;
+
 		public static List<AzurLaneShip> ships = new List<AzurLaneShip>();
 
 		static void Main(string[] args)
@@ -51,9 +53,12 @@ namespace AzurLaneWikiScrapersConsole
 				if (args.Contains("--events-data")) _downloadEventsData = true;
 				if (args.Contains("--events-images")) _downloadEventsImages = true;
 
+				if (args.Contains("--equipment-urls")) _downloadEquipmentUrls = true;
+
 				// Section options
 				if (args.Contains("--ships")) _downloadShipData = _downloadShipImages = _downloadShipUrls = true;
 				if (args.Contains("--events")) _downloadEventsData = _downloadEventsImages = true;
+				if (args.Contains("--equipment")) _downloadEquipmentUrls = true;
 
 				// All / All - Excluded options
 				if (args.Contains("--all"))
@@ -64,6 +69,8 @@ namespace AzurLaneWikiScrapersConsole
 
 					_downloadEventsData = true;
 					_downloadEventsImages = true;
+
+					_downloadEquipmentUrls = true;
 				}
 				if (args.Contains("--all-noimg"))
 				{
@@ -71,6 +78,8 @@ namespace AzurLaneWikiScrapersConsole
 					_downloadShipUrls = true;
 
 					_downloadEventsData = true;
+
+					_downloadEquipmentUrls = true;
 				}
 				if (args.Contains("--all-nodata"))
 				{
@@ -84,6 +93,12 @@ namespace AzurLaneWikiScrapersConsole
 			/// </summary>
 			AzurLaneShipSource[] shipSources = scrapers.UrlScraper.Execute();
 			AnsiConsole.MarkupLine("[gray]Loaded ship sources[/]");
+			AzurLaneEquipmentSource[] equipmentSources = scrapers.EquipmentUrlScraper.Execute();
+			AnsiConsole.MarkupLine("[gray]Loaded equipment sources[/]");
+
+			/// <sumamry>
+			/// Export ship urls
+			/// </summary>
 			if (_downloadShipUrls)
 			{
 				File.WriteAllText($"{_exportFolder}shipUrls.json", JsonConvert.SerializeObject(shipSources, Formatting.Indented));
@@ -179,6 +194,15 @@ namespace AzurLaneWikiScrapersConsole
 					}
 				});
 				AnsiConsole.MarkupLine("[lime]Exported Event Images![/]");
+			}
+
+			if (_downloadEquipmentUrls)
+			{
+				AnsiConsole.Status().Start("Scraping Equipment Urls...", ctx =>
+				{
+					AzurLaneEquipmentSource[] equipmentSources = scrapers.EquipmentUrlScraper.Execute();
+					File.WriteAllText($"{_exportFolder}equipmentUrls.json", JsonConvert.SerializeObject(equipmentSources, Formatting.Indented));
+				});
 			}
 		}
 	}


### PR DESCRIPTION
- Added Scraper for equipment urls
**NOTE**: This does not retrieve the equipment ids, this will be done in the equipment data scraper
- Added commandline options `--equipment` and `--equipment-urls`
